### PR TITLE
Add @types/jsbn to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "types": "dist/index.d.ts",
   "private": false,
   "dependencies": {
+    "@types/jsbn": "^1.2.29",
     "crypto-js": "^3.1.9-1",
     "jsbn": "^1.1.0"
   },
   "devDependencies": {
     "@types/crypto-js": "^3.1.43",
-    "@types/jsbn": "^1.2.29",
     "@types/node": "^11.13.8",
     "husky": "^2.1.0",
     "lint-staged": "^8.1.5",


### PR DESCRIPTION
Consumers will always get typecheck on BigInteger types (params and
return values).

Signed-off-by: Benjamin Große <benjamin@midokura.com>