### PR TITLE
Added complete signup/signin examples to readme

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ export { SRPConfig } from "./config";
 export { SRPParameters } from "./parameters";
 export { SRPRoutines } from "./routines";
 export { SRPClientSession, ISRPClientCredentials } from "./session-client";
+export { SRPServerSession } from "./session-server";
 export {
   createVerifierAndSalt,
   IVerifierAndSalt,

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
   "types": "dist/index.d.ts",
   "private": false,
   "dependencies": {
+    "@types/crypto-js": "^3.1.43",
     "@types/jsbn": "^1.2.29",
     "crypto-js": "^3.1.9-1",
     "jsbn": "^1.1.0"
   },
   "devDependencies": {
-    "@types/crypto-js": "^3.1.43",
     "@types/node": "^11.13.8",
     "husky": "^2.1.0",
     "lint-staged": "^8.1.5",


### PR DESCRIPTION
This patch also export server session class and adds missing
types definition of crypto-js package, since exported interfaces uses
these types.