### PR TITLE
Bump crypto-js from 3.1.9-1 to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@types/crypto-js": "^3.1.43",
     "@types/jsbn": "^1.2.29",
-    "crypto-js": "^3.1.9-1",
+    "crypto-js": "^4.0.0",
     "jsbn": "^1.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -499,10 +499,10 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-crypto-js@^3.1.9-1:
-  version "3.1.9-1"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
-  integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
+crypto-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
 
 date-fns@^1.27.2:
   version "1.30.1"


### PR DESCRIPTION
> In this version Math.random() has been replaced by the random methods of the native crypto module.

With new `crypto-js` version in browser we can rely on browser crypto random numbers instead of Math.random()