### PR TITLE
exclude src/crossEnvCrypto.ts from coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "build:esm": "yarn ttsc --project tsconfig.esm.json && cp node_modules/bigint-mod-arith/dist/bundles/bigint-mod-arith.iife.js demo/",
     "test": "yarn tape 'test/**/*.test.*' -r ts-node/register",
     "test:report": "TAPE_RAW_OUTPUT=1 yarn test | yarn tap-junit -o reports -n unit",
-    "nyc": "nyc -e .ts",
+    "nyc": "nyc -e .ts -x 'src/crossEnvCrypto.ts' -x 'test/**'",
     "coverage": "yarn nyc yarn test:report",
     "coverage:report": "yarn nyc --reporter cobertura --reporter html --report-dir reports/unit yarn test:report",
     "lint_formatter": "prettier -c 'src/**' 'test/**'",


### PR DESCRIPTION
browser crypto is tested with puppeteer and can never be covered with a
single coverage analysis tool.

will get us back to our precious 100%