### PR TITLE
de/serialization test of test steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,13 @@ SRP alone only prevents a man-in-the-middle attack from _reading_ the password, 
 
 Always use SRP in combination with HTTPS. Browsers can be vulnerable to: having malicious certificates installed beforehand, rogue certificates in the wild, server misconfiguration, bugs like the heartbleed attack, servers leaking password into errors and logs. SRP in the browser offers an additional hurdle and may prevent some mistakes from escalating.
 
-The client can choose to exclude the identity of its computations or not. If excluded, the id cannot be changed. But this problem is better solved by an application schema that separates "identity" from "authentication", so that one identity can have multiple authentications. This allows to switch identity + password, and also to user more than one way of logging in (think "login with email+password, google, or facebook").
+The client can choose to exclude the identity of its computations or not. If excluded, the id cannot be changed. But this problem is better solved by an application schema that separates "identity" from "authentication", so that one identity can have multiple authentications. This allows to switch identity + password, and also to use more than one way of logging in (think "login with email+password, google, or facebook").
+
+## Serialization
+
+The server "session" state (the server step 1 state) might not be easily kept in memory in case of e.g. a webserver (in constrast with a websocket session). In that case it is advised to either serialize and save username+salt+verifier into the session and recreate step1 from that data, or alternatively use the provided [serde](test/serialization.test.ts) functions to store and recover the state entirely.
+
+The client may also be serialized in either way. While the password is **never** kept in the client session state, storing or sending the state might still make your app vulnerable against some kind of replay attack.
 
 ## Notes
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "scripts": {
     "build": "yarn tsc --build tsconfig.json",
     "build:esm": "yarn ttsc --project tsconfig.esm.json",
-    "test": "yarn tape 'test/**/*.test.*' -r ts-node/register",
+    "test:none": "yarn tape -r ts-node/register",
+    "test": "yarn test:none 'test/**/*.test.*'",
     "test:report": "TAPE_RAW_OUTPUT=1 yarn test | yarn tap-junit -o reports -n unit",
     "nyc": "nyc -e .ts -x 'src/crossEnvCrypto.ts' -x 'test/**'",
     "coverage": "yarn nyc yarn test:report",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export {
   arrayBufferToBigInt,
   generateRandomBigInt,
 } from "./utils";
+export { serialize, deserialize } from "./serde";

--- a/src/serde.ts
+++ b/src/serde.ts
@@ -1,0 +1,66 @@
+import { SRPParameters } from "./parameters";
+import { SRPRoutines } from "./routines";
+import { SRPClientSessionStep1, SRPClientSessionStep2 } from "./session-client";
+import { SRPServerSessionStep1 } from "./session-server";
+
+/**
+ * Crude JSON-based deserialization that has just enough exceptions for tssrp6a
+ * classes.
+ * Needs the serialization string and the target class prototype, e.g.
+ * `SRPServerSessionStep1.prototype`.
+ */
+export function deserialize<
+  T extends
+    | SRPServerSessionStep1
+    | SRPClientSessionStep1
+    | SRPClientSessionStep2,
+>(str: string, proto: T): T {
+  const obj = JSON.parse(str, (key, value) => {
+    switch (key) {
+      case "routines":
+        value.__proto__ = SRPRoutines.prototype;
+        return value;
+      case "parameters":
+        value.__proto__ = SRPParameters.prototype;
+        return value;
+      case "":
+      case "NBits":
+      case "primeGroup":
+      case "identifier":
+      case "I":
+        return value;
+      case "IH":
+        return new Uint8Array(JSON.parse(value)).buffer;
+      case "H":
+        return SRPParameters.H[value];
+      default:
+        return BigInt(value);
+    }
+  });
+  obj.__proto__ = proto;
+  return obj;
+}
+
+/**
+ * Crude JSON-based serialization that has just enough exceptions for tssrp6a
+ * classes.
+ */
+export function serialize(
+  step: SRPServerSessionStep1 | SRPClientSessionStep1 | SRPClientSessionStep2,
+): string {
+  return JSON.stringify(step, (_key, value) => {
+    if (typeof value === "bigint") {
+      return value.toString();
+    } else if (value instanceof ArrayBuffer) {
+      return JSON.stringify(Array.from(new Uint8Array(value)));
+    } else if (typeof value === "function") {
+      for (const [key, fn] of Object.entries(SRPParameters.H)) {
+        if (value === fn) {
+          return key;
+        }
+      }
+      throw new Error("cannot serialize unknown hash function");
+    }
+    return value;
+  });
+}

--- a/src/session-client.ts
+++ b/src/session-client.ts
@@ -26,7 +26,7 @@ export class SRPClientSession {
   }
 }
 
-class SRPClientSessionStep1 {
+export class SRPClientSessionStep1 {
   constructor(
     private readonly routines: SRPRoutines,
     /**
@@ -69,7 +69,7 @@ class SRPClientSessionStep1 {
   }
 }
 
-class SRPClientSessionStep2 {
+export class SRPClientSessionStep2 {
   constructor(
     private readonly routines: SRPRoutines,
     /**

--- a/src/session-server.ts
+++ b/src/session-server.ts
@@ -40,7 +40,7 @@ export class SRPServerSession {
   }
 }
 
-class SRPServerSessionStep1 {
+export class SRPServerSessionStep1 {
   constructor(
     public readonly routines: SRPRoutines,
     /**

--- a/test/serialization.test.ts
+++ b/test/serialization.test.ts
@@ -1,0 +1,116 @@
+import { SRPParameters } from "../src/parameters";
+import { SRPRoutines } from "../src/routines";
+import {
+  SRPClientSession,
+  SRPClientSessionStep1,
+  SRPClientSessionStep2,
+} from "../src/session-client";
+import { SRPServerSession, SRPServerSessionStep1 } from "../src/session-server";
+import { createVerifierAndSalt, generateRandomString } from "../src/utils";
+import { serialize, deserialize } from "../src/serde";
+import { test } from "./tests";
+
+const TEST_ROUTINES = new SRPRoutines(new SRPParameters());
+
+test("#Server serde", async (t) => {
+  const testUsername = generateRandomString(10);
+  const testPassword = generateRandomString(15);
+
+  const { s: salt, v: verifier } = await createVerifierAndSalt(
+    TEST_ROUTINES,
+    testUsername,
+    testPassword,
+  );
+
+  // serialized server step1, and B
+  // B is sent back to client, server_str is stored into some kind of webserver
+  // session for this user
+  const [server_str, B] = await (async (): Promise<[string, bigint]> => {
+    const server = await new SRPServerSession(TEST_ROUTINES).step1(
+      testUsername,
+      salt,
+      verifier,
+    );
+    const B = server.B;
+
+    return [serialize(server), B];
+  })();
+
+  const client = await new SRPClientSession(TEST_ROUTINES).step1(
+    testUsername,
+    testPassword,
+  );
+
+  const client_step2 = await client.step2(salt, B);
+
+  // assume that server_str was stored/loaded from some session
+  const server_step1 = deserialize(server_str, SRPServerSessionStep1.prototype);
+  const M2 = await server_step1.step2(client_step2.A, client_step2.M1);
+
+  await client_step2.step3(M2);
+  t.pass("all steps passed");
+});
+
+test("#Client serde", async (t) => {
+  const testUsername = generateRandomString(10);
+  const testPassword = generateRandomString(15);
+
+  const { s: salt, v: verifier } = await createVerifierAndSalt(
+    TEST_ROUTINES,
+    testUsername,
+    testPassword,
+  );
+
+  const client_step1_str = await (async (): Promise<string> => {
+    const client = await new SRPClientSession(TEST_ROUTINES).step1(
+      testUsername,
+      testPassword,
+    );
+    return serialize(client);
+  })();
+
+  const server = await new SRPServerSession(TEST_ROUTINES).step1(
+    testUsername,
+    salt,
+    verifier,
+  );
+
+  const client = deserialize(client_step1_str, SRPClientSessionStep1.prototype);
+  const [client_step2_str, A, M1] = await (async (): Promise<
+    [string, bigint, bigint]
+  > => {
+    const client_step2 = await client.step2(salt, server.B);
+    return [serialize(client_step2), client_step2.A, client_step2.M1];
+  })();
+
+  const M2 = await server.step2(A, M1);
+
+  await deserialize(client_step2_str, SRPClientSessionStep2.prototype).step3(
+    M2,
+  );
+  t.pass("all steps passed");
+});
+
+test("#serde with unknown hash function throws", async (t) => {
+  const testUsername = generateRandomString(10);
+  const testPassword = generateRandomString(15);
+
+  const { s: salt, v: verifier } = await createVerifierAndSalt(
+    TEST_ROUTINES,
+    testUsername,
+    testPassword,
+  );
+
+  const params = new SRPParameters(SRPParameters.PrimeGroup[2048], (data) =>
+    Promise.resolve(data),
+  );
+  const server = await new SRPServerSession(new SRPRoutines(params)).step1(
+    testUsername,
+    salt,
+    verifier,
+  );
+
+  t.throws(() => {
+    serialize(server);
+  });
+});


### PR DESCRIPTION
It might be desirable to serialize the server step 1. For example, in a
typical webserver, the connection is stateless and there is some kind of
session mechanism that has some storage layer.

It is possible to save username+salt+verifier in that session storage,
so that step 1 can be recreated.

For convenience, this patch adds a `serialize` module that can stringify
server and client steps and rehydrate with the `deserialize` complement.

I don't think client session steps should be serialized, however it is
also supported.

fixes #71 